### PR TITLE
Use PureComponent and rerender on new props

### DIFF
--- a/lib/CustomQRCode.js
+++ b/lib/CustomQRCode.js
@@ -10,14 +10,14 @@ This is a Customisable QR Code Component for React Native Applications.
 
 
 //-----------------------------Imports-----------------------------------
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { View, Image, Text, Button } from 'react-native';
 import PropTypes from 'prop-types';
 import { generateQRCode } from './QRCodeGenerator';
 import Svg, { Rect, Circle, Path } from 'react-native-svg'
 
 //-----------------------------Component---------------------------------
-export default class CustomQRCode extends Component {
+export default class CustomQRCode extends PureComponent {
 
 //-----------------------Properties---------------------
   static propTypes = {
@@ -44,18 +44,6 @@ export default class CustomQRCode extends Component {
     logoSize: 25,
     ecl: 'H'
   };
-
-//---------------------Constructor---------------------
-   constructor(props) {
-      super();
-      this.state = {
-        pieces: (<View></View>)
-      }
-   }
-
-   componentDidMount(){
-     this.setState({pieces:this.getPieces()});
-   }
 
 //-----------------------Methods-----------------------
 
@@ -90,7 +78,6 @@ export default class CustomQRCode extends Component {
      }
 
      //console.log(pieces);
-     //this.setState({pieces:pieces});
 
      return (<Svg style={{backgroundColor:'white',borderRadius:2,borderColor:'red',height:200,width:200}}>{pieces}</Svg>);
    }
@@ -262,9 +249,8 @@ export default class CustomQRCode extends Component {
       else{
         return (
           <View backgroundColor='blue'>
-            <Button style={{backgroundColor:'yellow'}} title="press me" onPress={()=> {this.setState({pieces:this.getPieces()});console.log(this.state.pieces)}}><Text>Press me</Text></Button>
             <Text>We got here</Text>
-            {this.state.pieces}
+            {this.getPieces()}
               <Image src={this.props.logo} style={{width: this.props.logoSize, height: this.props.logoSize, position: 'absolute', left: ((this.props.size/2)-(this.props.logoSize/2)), top: ((this.props.size/2)-(this.props.logoSize/2))}}/>
           </View>
         )

--- a/lib/QRCode.js
+++ b/lib/QRCode.js
@@ -10,7 +10,7 @@ This is a Customisable QR Code Component for React Native Applications.
 
 
 //-----------------------------Imports-----------------------------------
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { View, Image, Text, Button } from 'react-native';
 import PropTypes from 'prop-types';
 import { generateQRCode } from './QRCodeGenerator.js';
@@ -18,7 +18,7 @@ import { drawPiece } from './styles';
 import Svg, { Rect, Circle, Polygon, G, Path, Defs, ClipPath, LinearGradient, Stop } from 'react-native-svg';
 
 //-----------------------------Component---------------------------------
-export default class QRCode extends Component {
+export default class QRCode extends PureComponent {
 
 //-----------------------Properties---------------------
   static propTypes = {
@@ -51,18 +51,6 @@ export default class QRCode extends Component {
     logoSize: 100,
     ecl: 'H'
   };
-
-//---------------------Constructor---------------------
-   constructor(props) {
-      super();
-      this.state = {
-        pieces: (<View></View>)
-      }
-   }
-
-   componentDidMount(){
-     this.setState({pieces:this.getPieces()});
-   }
 
 //-----------------------Methods-----------------------
 
@@ -251,8 +239,7 @@ export default class QRCode extends Component {
 
   //---------------------Rendering-----------------------
 
-    //In onComponentDidMount, this.state.pieces is set to contain the QR Code which is generated in 'getPieces'
     render () {
-        return this.state.pieces;
+        return this.getPieces();
     }
 }


### PR DESCRIPTION
Having pieces rendered only on component mount is against nature of React and does not allow to rerender component if new props are passed. Developer would have to unmount and mount QRCode imperatively which is a hack.

Using `PureComponent` allows rerendering to happen if props change but will not call render method if props are the same.

Fixes #6 